### PR TITLE
解决getmrnaexpr时TCGAbiolinks::GDCquery方法的workflow.type参数报错问题

### DIFF
--- a/R/getmrnaexpr.R
+++ b/R/getmrnaexpr.R
@@ -85,7 +85,7 @@ getmrnaexpr <- function(project) {
     project = project,
     data.category = "Transcriptome Profiling",
     data.type = "Gene Expression Quantification",
-    workflow.type = "STAR - count"
+    workflow.type = "STAR - Counts"
   )
   message("\n=> Downloading begins. \n")
   TCGAbiolinks::GDCdownload(query, files.per.chunk = 100)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ```R
 # 安装bioconductor上面的R包
-# 首先要改镜像，下面是北大的镜像，有时会有问题，可更改其他镜像试试（自己百度下喽~）
+# 首先要改镜像，下面是清华的镜像，有时会有问题，可更改其他镜像试试（自己百度下喽~）
 options(BioC_mirror="https://mirrors.tuna.tsinghua.edu.cn/bioconductor")
 if(!require("BiocManager")) install.packages("BiocManager")
 if(!require("TCGAbiolinks")) BiocManager::install("TCGAbiolinks")


### PR DESCRIPTION
作者您好，非常感谢您开发了如此方便的R包
我在按教程安装清华镜像源的最新的TCGAbiolinks依赖后，getmrnaexpr方法会报错，按照报错信息排查发现TCGAbiolinks::GDCquery方法的workflow.type参数应从"STAR - count"改为"STAR - Counts"，推测可能与TCGAbiolinks版本不同有关，更改后getmrnaexpr方法正常运行